### PR TITLE
fix windows yarn dev

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "lint:check": "eslint '*{,/**/*}.{js,ts,tsx}' --report-unused-disable-directives",
     "lint:fix": "eslint '*{,/**/*}.{js,ts,tsx}' --quiet --fix",
     "test": "echo 0",
-    "build": "yarn clear && NODE_ENV=production webpack --config ./webpack.config.js --display-error-details"
+    "build": "yarn clear cross-env && NODE_ENV=production webpack --config ./webpack.config.js --display-error-details"
   },
   "repository": {
     "type": "git",
@@ -60,6 +60,7 @@
     "babel-loader": "^8.1.0",
     "babel-plugin-import": "^1.13.0",
     "base64-inline-loader": "^1.1.1",
+    "cross-env": "^7.0.2",
     "css-loader": "^3.5.2",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.10.1",
@@ -93,7 +94,6 @@
     "webpack-cli": "^3.3.11"
   },
   "devDependencies": {
-    "cross-env": "^7.0.2",
     "webpack-dev-server": "^3.10.3"
   }
 }

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -154,7 +154,7 @@ const pushWebpackConfig = (app) => {
         t9config.bundles.distFolder,
         t9config.bundles.publicPath,
       ),
-      publicPath: path.join(t9config.bundles.publicPath),
+      publicPath: t9config.bundles.publicPath,
     },
     plugins: [
       // https://webpack.js.org/plugins/hot-module-replacement-plugin/


### PR DESCRIPTION
fix Windows development environment. by : 
- modify the path of the bundle in Webpack.
- added cross-env to production, 

Fixes #39 

## Checklist

- [ x ] Affected `frontend`
