### PR TITLE
🐞 fix: data generation breaks when no content

### DIFF
--- a/data/src/utils/data.ts
+++ b/data/src/utils/data.ts
@@ -34,7 +34,10 @@ export const getDataEntry = (path: string, include?: string[]) => {
   }
 
   // Read content.md
-  if (!include || include.includes("content"))
+  if (
+    (!include || include.includes("content")) &&
+    fse.existsSync(`${path}/content.md`)
+  )
     entry = {
       ...entry,
       content: String(fse.readFileSync(`${path}/content.md`)),


### PR DESCRIPTION
Fixed bug where Data generation breaks when there is no content.md file

## Checklist

- [ ] `yarn test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://github.com/dzcode-io/dzcode.io/blob/master/.github/CONTRIBUTING.md#coding-guidelines)
- [x] Affected `data`
- [ ] Affected `frontend`
