### PR TITLE
⚠️ warnings are now hidden from CI output

### DIFF
--- a/.github/workflows/cgl-data.yml
+++ b/.github/workflows/cgl-data.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           cd data
           yarn
-          yarn eslint:check
+          yarn eslint:check --quiet
           yarn prettier:check
 
         env:

--- a/.github/workflows/cgl-frontend.yml
+++ b/.github/workflows/cgl-frontend.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           cd frontend
           yarn
-          yarn eslint:check
+          yarn eslint:check --quiet
           yarn prettier:check
 
         env:

--- a/.github/workflows/cgl-fullstack.yml
+++ b/.github/workflows/cgl-fullstack.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           cd fullstack
           yarn
-          yarn eslint:check
+          yarn eslint:check --quiet
           yarn prettier:check
 
         env:


### PR DESCRIPTION
Annoying Warnings are now hidden in CI logs, only error are shown

## Checklist

- [ ] `yarn test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://github.com/dzcode-io/dzcode.io/blob/master/.github/CONTRIBUTING.md#coding-guidelines)
- [ ] Affected `data`
- [ ] Affected `frontend`
