### PR TITLE
fixing githubURI project wrong format

### DIFF
--- a/data/models/projects/React_Native_Currency_Converter/info.json
+++ b/data/models/projects/React_Native_Currency_Converter/info.json
@@ -1,7 +1,7 @@
 {
   "title": "Currency Converter React Native",
   "description": "Currency converters with real-time information on bank exchange rates with more than 35 country.",
-  "githubURI": "https://github.com/ilies-space/currency_converter_rn",
+  "githubURI": "ilies-space/currency_converter_rn",
   "slug": "Currency_Converter_React_Native",
   "image": "https://github.com/ilies-space/currency_converter_rn/blob/main/screenShots/ui_vision.jpg"
 }


### PR DESCRIPTION
i've did a small mistake , adding my open source project link in the wrong format that cause to redirect user to wrong link : https://github.com/https://github.com/ilies-space/currency_converter_rn .
now i have deleted the ("https://github.com/") from the info.json/githubURI
and that will fix the problem .
Thank you