### PR TITLE
removed social footer from content

### DIFF
--- a/data/models/articles/A_Python_Website_No_Framework_Needed/content.md
+++ b/data/models/articles/A_Python_Website_No_Framework_Needed/content.md
@@ -102,7 +102,3 @@ in the next part, we will write a code to render an html file, create multiple p
 [The u wsgi project](https://uwsgi-docs.readthedocs.io/en/latest/)
 
 [Simple Python Framework from Scratch](https://mattscodecave.com/posts/simple-python-framework-from-scratch.html)
-
-## Social footer
-
-By Toumi abderrahmane [twitter](https://twitter.com/Abderrahmaneend) . [github](https://github.com/abderrahmaneMustapha)

--- a/data/models/articles/A_Python_Website_No_Framework_Needed_PART_2/content.md
+++ b/data/models/articles/A_Python_Website_No_Framework_Needed_PART_2/content.md
@@ -126,7 +126,3 @@ inputs -----------------  b'text=azaze'
 [Do it your self framework](https://paste.readthedocs.io/en/latest/do-it-yourself-framework.html)
 
 [WSGI handle post request](http://wsgi.tutorial.codepoint.net/parsing-the-request-post)
-
-## Social footer
-
-By Toumi abderrahmane [twitter](https://twitter.com/Abderrahmaneend) . [github](https://github.com/abderrahmaneMustapha)

--- a/data/models/articles/Open_source/content.md
+++ b/data/models/articles/Open_source/content.md
@@ -64,7 +64,3 @@ The open-source development model consists of 5 main steps:
 - Exposure: Active open-source contributions emphasize your expertise and knowledge more than certificates alone will ever do. By contributing to OSS you set skills out to notice by potential employers. Don’t tell them that you can do the job. Show them.
 
 - Networking: Because working on OSS involves interacting with others. Contributing to OSS will allow you to meet new interesting people, exchange ideas, and grow as a developer. Setting aside time to work on OSS can spark plenty of quality discussions, even end up in friendships, or finding a mentor.
-
-&nbsp;
-
-By Nour Tine (tinenourelhouda@gmail.com)

--- a/data/models/articles/Send_Emails_With_Django_and_Gmail_A_Better_Way/content.md
+++ b/data/models/articles/Send_Emails_With_Django_and_Gmail_A_Better_Way/content.md
@@ -111,7 +111,3 @@ You can use SendGrid, Mailgun, Sendinblue... for your apps too
 don't forget to put your key in a .env file.
 
 [An Introduction to Environment Variables and How to Use Them](https://medium.com/chingu/an-introduction-to-environment-variables-and-how-to-use-them-f602f66d15fa)
-
-## Social footer
-
-By Toumi abderrahmane [twitter](https://twitter.com/Abderrahmaneend) . [github](https://github.com/abderrahmaneMustapha)

--- a/data/models/articles/Use_Conventional_Commits_To_Contribute_To_DZCode/content.md
+++ b/data/models/articles/Use_Conventional_Commits_To_Contribute_To_DZCode/content.md
@@ -81,7 +81,3 @@ The **footer** should contain any information about Breaking Changes and is also
 - [Alvaro Torres Carrasco article](https://dev.to/alvarotorresc/conventional-commits-1an9)
 - [A Case For Conventional Commits in Git by Tom Feron](https://medium.com/better-programming/a-case-for-conventional-commits-in-git-d70c65245009)
 - [feat(conventional_commits): signal breaking changes in commit titles by apereo community](https://apereo.github.io/2018/07/07/indicate-breaks-in-conventional-commit-titles/)
-
-## Social footer
-
-By Toumi abderrahmane [twitter](https://twitter.com/Abderrahmaneend) . [github](https://github.com/abderrahmaneMustapha)

--- a/data/models/articles/top-articles.json
+++ b/data/models/articles/top-articles.json
@@ -1,5 +1,6 @@
 {
   "items": [
+    "Send_Emails_With_Django_and_Gmail_A_Better_Way",
     "Use_Conventional_Commits_To_Contribute_To_DZCode",
     "Open_source",
     "A_Python_Website_No_Framework_Needed",


### PR DESCRIPTION
# Description

as a followup to #260 , now there is no need to add a social footer in `content.md`, as it now on the **Authors** section on the bottom
