### PR TITLE
Remove "mode" from PaletteOptions

### DIFF
--- a/web/src/apps/main/components/markdown/index.tsx
+++ b/web/src/apps/main/components/markdown/index.tsx
@@ -2,14 +2,19 @@ import ReactMarkdown, { MarkdownToJSX } from "markdown-to-jsx";
 
 import { FC } from "react";
 import { LinkV2 } from "src/components/link-v2";
+import { StateInterface } from "src/apps/main/redux";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import Typography from "@material-ui/core/Typography";
 import prism from "react-syntax-highlighter/dist/esm/styles/prism/prism";
 import tomorrow from "react-syntax-highlighter/dist/esm/styles/prism/tomorrow";
+import { useSelector } from "react-redux";
 import { useTheme } from "@material-ui/core/styles";
 
 export const Markdown: FC<ReactMarkdown> = (markdownProps) => {
   const theme = useTheme();
+  const darkMode = useSelector<StateInterface, boolean>(
+    (state) => state.settings.darkMode,
+  );
 
   return (
     <ReactMarkdown
@@ -64,7 +69,7 @@ export const Markdown: FC<ReactMarkdown> = (markdownProps) => {
                       ? props.className.replace("lang-", "")
                       : null
                   }
-                  style={theme.palette.mode === "dark" ? tomorrow : prism}
+                  style={darkMode ? tomorrow : prism}
                 />
               );
             },

--- a/web/src/apps/main/components/theme/palettes/dark.ts
+++ b/web/src/apps/main/components/theme/palettes/dark.ts
@@ -2,7 +2,6 @@ import { PaletteOptions } from "@material-ui/core/styles/createPalette";
 import { colors } from "@material-ui/core";
 const contrast = "#282c34";
 export const darkPalette: PaletteOptions = {
-  mode: "dark",
   primary: {
     contrastText: contrast,
     dark: colors.green[900],

--- a/web/src/apps/main/components/theme/palettes/light.ts
+++ b/web/src/apps/main/components/theme/palettes/light.ts
@@ -2,7 +2,6 @@ import { PaletteOptions } from "@material-ui/core/styles/createPalette";
 import { colors } from "@material-ui/core";
 const contrast = "#282c34";
 export const lightPalette: PaletteOptions = {
-  mode: "light",
   primary: {
     contrastText: contrast,
     dark: "#2B9348",


### PR DESCRIPTION
Fix the scrollbar issue #267  on dark mode

scrollbar becomes bold and sticky on dark mode, the issue appears due to including the field  `mode` on `PaletteOptions`  which is not defined in the interface.
