### PR TITLE
Fix/duplicate authors

### DIFF
--- a/data/models/documentation/About_dzcode_io/info.json
+++ b/data/models/documentation/About_dzcode_io/info.json
@@ -1,5 +1,6 @@
 {
   "title": "About dzcode.io website",
   "description": "Find guides, tutorials and all things related to contributing the dzcode.io website.",
-  "image": "https://images.unsplash.com/photo-1481487196290-c152efe083f5?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=800&q=100"
+  "image": "https://images.unsplash.com/photo-1481487196290-c152efe083f5?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=800&q=100",
+  "authors": ["ZibanPirate"]
 }

--- a/data/models/documentation/Git_Basics/info.json
+++ b/data/models/documentation/Git_Basics/info.json
@@ -1,5 +1,6 @@
 {
   "title": "Git Basics",
   "description": "Learn the basic of GIT version control, just the things you need daily in work.",
-  "image": "https://images.unsplash.com/photo-1481487196290-c152efe083f5?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=800&q=100"
+  "image": "https://images.unsplash.com/photo-1481487196290-c152efe083f5?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=800&q=100",
+  "authors": ["ZibanPirate"]
 }

--- a/web/src/apps/main/pages/articles/content/index.tsx
+++ b/web/src/apps/main/pages/articles/content/index.tsx
@@ -3,10 +3,6 @@ import "./style.scss";
 import { Dispatch, StateInterface } from "src/apps/main/redux";
 import { FC, useEffect } from "react";
 import { createStyles, makeStyles } from "@material-ui/core/styles";
-import {
-  fetchCurrentArticle,
-  fetchCurrentArticleAuthors,
-} from "src/apps/main/redux/actions/articles-page";
 import { useDispatch, useSelector } from "react-redux";
 
 import { ArticlesPageState } from "src/apps/main/redux/reducers/articles-page";
@@ -23,6 +19,7 @@ import Skeleton from "@material-ui/lab/Skeleton";
 import { SpeedDial } from "src/apps/main/components/speed-dial";
 import TwitterIcon from "@material-ui/icons/Twitter";
 import Typography from "@material-ui/core/Typography";
+import { fetchCurrentArticle } from "src/apps/main/redux/actions/articles-page";
 
 const actions = [
   { icon: <EditIcon />, name: "Edit This Article" },

--- a/web/src/apps/main/redux/actions/articles-page/index.ts
+++ b/web/src/apps/main/redux/actions/articles-page/index.ts
@@ -88,38 +88,38 @@ export const fetchCurrentArticleContributors = (): ThunkResult<
 /**
  * Fetches the authors of the an current article
  */
-export const fetchCurrentArticleAuthors = (): ThunkResult<
+const fetchCurrentArticleAuthors = (): ThunkResult<
   ArticlesPageState | ArticlesState
 > => async (dispatch, getState) => {
   const { currentArticle } = getState().articlesPage;
 
-  if (currentArticle) {
-    const githubAuthors = (
-      await Promise.all(
-        currentArticle.authors?.map((author) => {
-          return Axios.get<GithubUser>(apiURL + `/github/user/${author}`);
-        }) || [],
-      )
-    ).map((response) => {
-      return response.data;
-    });
+  if (!currentArticle || Array.isArray(currentArticle.githubAuthors)) return;
 
-    //  getting the  most recent  current article
-    const mrCurrentArticle =
-      getState().articlesPage.currentArticle || currentArticle;
+  const githubAuthors = (
+    await Promise.all(
+      currentArticle.authors?.map((author) => {
+        return Axios.get<GithubUser>(apiURL + `/github/user/${author}`);
+      }) || [],
+    )
+  ).map((response) => {
+    return response.data;
+  });
 
-    // update our page state
+  //  getting the  most recent  current article
+  const mrCurrentArticle =
+    getState().articlesPage.currentArticle || currentArticle;
 
-    dispatch({
-      type: "UPDATE_ARTICLES_PAGE",
-      payload: { currentArticle: { ...mrCurrentArticle, githubAuthors } },
-    });
-    // update our cache state
-    dispatch({
-      type: "UPDATE_ARTICLES",
-      payload: { list: [{ ...mrCurrentArticle, githubAuthors }] },
-    });
-  }
+  // update our page state
+
+  dispatch({
+    type: "UPDATE_ARTICLES_PAGE",
+    payload: { currentArticle: { ...mrCurrentArticle, githubAuthors } },
+  });
+  // update our cache state
+  dispatch({
+    type: "UPDATE_ARTICLES",
+    payload: { list: [{ ...mrCurrentArticle, githubAuthors }] },
+  });
 };
 
 /**

--- a/web/src/apps/main/redux/actions/articles-page/index.ts
+++ b/web/src/apps/main/redux/actions/articles-page/index.ts
@@ -58,31 +58,31 @@ export const fetchCurrentArticleContributors = (): ThunkResult<
   ArticlesPageState | ArticlesState
 > => async (dispatch, getState) => {
   const { currentArticle } = getState().articlesPage;
-  if (currentArticle && !currentArticle.contributors) {
-    const response = await Axios.get<GithubUser[]>(
-      apiURL + `/contributors?articleSlug=${currentArticle.slug}`,
-    );
+  if (!currentArticle || Array.isArray(currentArticle.contributors)) return;
 
-    if (response.data.hasOwnProperty("error")) {
-      throw Error("error_fetching_contributors");
-    }
+  const response = await Axios.get<GithubUser[]>(
+    apiURL + `/contributors?articleSlug=${currentArticle.slug}`,
+  );
 
-    const contributors = response.data;
-
-    //  getting the  most recent  current article
-    const mrCurrentArticle =
-      getState().articlesPage.currentArticle || currentArticle;
-    // update our page state
-    dispatch({
-      type: "UPDATE_ARTICLES_PAGE",
-      payload: { currentArticle: { ...mrCurrentArticle, contributors } },
-    });
-    // update our cache state
-    dispatch({
-      type: "UPDATE_ARTICLES",
-      payload: { list: [{ ...mrCurrentArticle, contributors }] },
-    });
+  if (response.data.hasOwnProperty("error")) {
+    throw Error("error_fetching_contributors");
   }
+
+  const contributors = response.data;
+
+  //  getting the  most recent  current article
+  const mrCurrentArticle =
+    getState().articlesPage.currentArticle || currentArticle;
+  // update our page state
+  dispatch({
+    type: "UPDATE_ARTICLES_PAGE",
+    payload: { currentArticle: { ...mrCurrentArticle, contributors } },
+  });
+  // update our cache state
+  dispatch({
+    type: "UPDATE_ARTICLES",
+    payload: { list: [{ ...mrCurrentArticle, contributors }] },
+  });
 };
 
 /**

--- a/web/src/apps/main/redux/actions/documentation-page/index.ts
+++ b/web/src/apps/main/redux/actions/documentation-page/index.ts
@@ -87,38 +87,38 @@ const fetchCurrentDocumentContributors = (): ThunkResult<
 /**
  * Fetches the authors of the an current document
  */
-export const fetchCurrentArticleAuthors = (): ThunkResult<
+const fetchCurrentDocumentAuthors = (): ThunkResult<
   LearnPageState | DocumentationState
 > => async (dispatch, getState) => {
   const { currentDocument } = getState().learnPage;
 
-  if (currentDocument) {
-    const githubAuthors = (
-      await Promise.all(
-        currentDocument.authors?.map((author) => {
-          return Axios.get<GithubUser>(apiURL + `/github/user/${author}`);
-        }) || [],
-      )
-    ).map((response) => {
-      return response.data;
-    });
+  if (!currentDocument || Array.isArray(currentDocument.githubAuthors)) return;
 
-    //  getting the  most recent  current article
-    const mrCurrentDocument =
-      getState().learnPage.currentDocument || currentDocument;
+  const githubAuthors = (
+    await Promise.all(
+      currentDocument.authors?.map((author) => {
+        return Axios.get<GithubUser>(apiURL + `/github/user/${author}`);
+      }) || [],
+    )
+  ).map((response) => {
+    return response.data;
+  });
 
-    // update our page state
+  //  getting the  most recent  current article
+  const mrCurrentDocument =
+    getState().learnPage.currentDocument || currentDocument;
 
-    dispatch({
-      type: "UPDATE_LEARN_PAGE",
-      payload: { currentDocument: { ...mrCurrentDocument, githubAuthors } },
-    });
-    // update our cache state
-    dispatch({
-      type: "UPDATE_DOCUMENTATION",
-      payload: { list: [{ ...mrCurrentDocument, githubAuthors }] },
-    });
-  }
+  // update our page state
+
+  dispatch({
+    type: "UPDATE_LEARN_PAGE",
+    payload: { currentDocument: { ...mrCurrentDocument, githubAuthors } },
+  });
+  // update our cache state
+  dispatch({
+    type: "UPDATE_DOCUMENTATION",
+    payload: { list: [{ ...mrCurrentDocument, githubAuthors }] },
+  });
 };
 
 /**
@@ -143,7 +143,7 @@ export const fetchCurrentDocument = (): ThunkResult<
       payload: { currentDocument: cashedDocument },
     });
     // Fetch authors
-    dispatch(fetchCurrentArticleAuthors());
+    dispatch(fetchCurrentDocumentAuthors());
     // Fetch contributors
     dispatch(fetchCurrentDocumentContributors());
   } else {
@@ -172,7 +172,7 @@ export const fetchCurrentDocument = (): ThunkResult<
         payload: { list: [currentDocument] },
       });
       // Fetch authors
-      dispatch(fetchCurrentArticleAuthors());
+      dispatch(fetchCurrentDocumentAuthors());
       // Fetch contributors
       dispatch(fetchCurrentDocumentContributors());
     } catch (error) {

--- a/web/src/apps/main/redux/actions/documentation-page/index.ts
+++ b/web/src/apps/main/redux/actions/documentation-page/index.ts
@@ -53,34 +53,35 @@ export const fetchDocumentationList = (): ThunkResult<LearnPageState> => async (
 /**
  * Fetches the contributors of the an current document
  */
-export const fetchCurrentDocumentContributors = (): ThunkResult<
+const fetchCurrentDocumentContributors = (): ThunkResult<
   LearnPageState | DocumentationState
 > => async (dispatch, getState) => {
   const { currentDocument } = getState().learnPage;
-  if (currentDocument && !currentDocument.contributors) {
-    const response = await Axios.get<GithubUser[]>(
-      apiURL + `/contributors?documentSlug=${currentDocument.slug}`,
-    );
 
-    if (response.data.hasOwnProperty("error")) {
-      throw Error("error_fetching_contributors");
-    }
+  if (!currentDocument || Array.isArray(currentDocument.contributors)) return;
 
-    const contributors = response.data;
+  const response = await Axios.get<GithubUser[]>(
+    apiURL + `/contributors?documentSlug=${currentDocument.slug}`,
+  );
 
-    const mrCurrentDocument =
-      getState().learnPage.currentDocument || currentDocument;
-    // update our page state
-    dispatch({
-      type: "UPDATE_LEARN_PAGE",
-      payload: { currentDocument: { ...mrCurrentDocument, contributors } },
-    });
-    // update our cache state
-    dispatch({
-      type: "UPDATE_DOCUMENTATION",
-      payload: { list: [{ ...mrCurrentDocument, contributors }] },
-    });
+  if (response.data.hasOwnProperty("error")) {
+    throw Error("error_fetching_contributors");
   }
+
+  const contributors = response.data;
+
+  const mrCurrentDocument =
+    getState().learnPage.currentDocument || currentDocument;
+  // update our page state
+  dispatch({
+    type: "UPDATE_LEARN_PAGE",
+    payload: { currentDocument: { ...mrCurrentDocument, contributors } },
+  });
+  // update our cache state
+  dispatch({
+    type: "UPDATE_DOCUMENTATION",
+    payload: { list: [{ ...mrCurrentDocument, contributors }] },
+  });
 };
 
 /**


### PR DESCRIPTION
# Description

fixed a bug observed on stage when #260 #264 features deployed, this was due to `mergeDeep` duplicating array entries, so i used `Object.assign` instead

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
