### PR TITLE
changed "master" keyword to "main" everywhere in the repo

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,9 +1,9 @@
 # Contributing to dzcode.io
 
 Contributions are always welcome. Before contributing please read the
-[code of conduct](https://github.com/dzcode-io/dzcode.io/blob/master/.github/CODE_OF_CONDUCT.md) &
+[code of conduct](https://github.com/dzcode-io/dzcode.io/blob/main/.github/CODE_OF_CONDUCT.md) &
 [search the issue tracker](https://github.com/dzcode-io/dzcode.io/issues); your issue
-may have already been discussed or fixed in `master`. To contribute,
+may have already been discussed or fixed in `main`. To contribute,
 [fork](https://help.github.com/articles/fork-a-repo/) dzcode.io, commit your changes,
 & [send a pull request](https://help.github.com/articles/using-pull-requests/).
 
@@ -49,4 +49,4 @@ established in the code.
   [JSDoc-style](http://www.2ality.com/2011/08/jsdoc-intro.html) comments for
   functions.
 
-Guidelines are following the [.editorconfig](https://github.com/dzcode-io/dzcode.io/blob/master/.editorconfig) file.
+Guidelines are following the [.editorconfig](https://github.com/dzcode-io/dzcode.io/blob/main/.editorconfig) file.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ yarn dev
 
 ## Contributing
 
-To get started see [the contributing guidelines](https://github.com/dzcode-io/dzcode.io/blob/master/.github/CONTRIBUTING.md).
+To get started see [the contributing guidelines](https://github.com/dzcode-io/dzcode.io/blob/main/.github/CONTRIBUTING.md).
 
 ### Before You Create a Pull Request
 

--- a/data/models/projects/ReadMe.md
+++ b/data/models/projects/ReadMe.md
@@ -21,7 +21,7 @@ All you need is a **_Good Project_**.
 
 ## Adding Your project To Dzcode
 
-Projects on **[dzCode.io](https://dzcode.io)** are found under the folder `data/projects` of our **[dzcode.io Github repo](https://github.com/dzcode-io/dzcode.io/tree/master/data/projects)**.
+Projects on **[dzCode.io](https://dzcode.io)** are found under the folder `data/projects` of our **[dzcode.io Github repo](https://github.com/dzcode-io/dzcode.io/tree/main/data/projects)**.
 
 To add new project simply do the following:
 


### PR DESCRIPTION
# Description

In the repo still there are some words left from the old branch naming convention, this PR ensures that we use "main" instead as the main branch everywhere in the repo.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
