### PR TITLE
Chore: mobile code cleanup 3

### DIFF
--- a/mobile/.eslintignore
+++ b/mobile/.eslintignore
@@ -3,7 +3,7 @@ node_modules/
 npm-debug.*
 web-build/
 coverage
-src/.common
+src/_common
 
 # ignorin native code
 android/

--- a/mobile/.gitignore
+++ b/mobile/.gitignore
@@ -9,7 +9,7 @@ npm-debug.*
 *.orig.*
 web-build/
 coverage
-src/.common
+src/_common
 
 # ignorin native code
 android/

--- a/mobile/.prettierignore
+++ b/mobile/.prettierignore
@@ -10,7 +10,7 @@ coverage
 *.mobileprovision
 *.orig.*
 yarn.lock
-src/.common
+src/_common
 
 # ignorin native code
 android/

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -8,7 +8,7 @@
     "url": "https://omarbelghaouti.space/"
   },
   "scripts": {
-    "common:sync": "rimraf ./src/.common && syncdir ../common/src ./src/.common -c",
+    "common:sync": "rimraf ./src/_common && syncdir ../common/src ./src/_common -c",
     "common:sync:watch": "yarn common:sync --watch",
     "expo": "expo",
     "dev": "expo start",

--- a/mobile/src/config/index.ts
+++ b/mobile/src/config/index.ts
@@ -1,4 +1,4 @@
-import { fsConfig } from "../.common/config";
+import { fsConfig } from "../_common/config";
 import { getEnv } from "../utils/env";
 
 export const fullstackConfig = fsConfig(getEnv(), { hostname: process.env.LOCAL_API_HOST });

--- a/mobile/src/redux/actions/articles-screen/index.ts
+++ b/mobile/src/redux/actions/articles-screen/index.ts
@@ -1,4 +1,4 @@
-import { Article } from "../../../.common/types";
+import { Article } from "../../../_common/types";
 import { ArticlesScreenState } from "../../reducers/articles-screen";
 import { ThunkResult } from "../..";
 import { fullstackConfig } from "../../../config";

--- a/mobile/src/redux/actions/articles-screen/index.ts
+++ b/mobile/src/redux/actions/articles-screen/index.ts
@@ -1,16 +1,12 @@
-import { Article } from "../../../_common/types";
 import { ArticlesScreenState } from "../../reducers/articles-screen";
 import { ThunkResult } from "../..";
 import { fetchV2 } from "../../../utils/fetch";
-import { fullstackConfig } from "../../../config";
-
-const dataURL = fullstackConfig.data.url;
 
 /**
  * @function fetchArticles
  * @description Fetch articles from the server and pass them to the reducer
  */
-export const fetchArticles = (): ThunkResult<ArticlesScreenState> => async (dispatch, getState) => {
+export const fetchArticles = (): ThunkResult<ArticlesScreenState> => async (dispatch) => {
   dispatch({
     type: "UPDATE_ARTICLES_SCREEN",
     payload: { refreshing: true },
@@ -42,13 +38,12 @@ export const fetchArticle =
     });
     try {
       const { articles } = getState().articlesScreen;
-      const response = await fetch(`${dataURL}/articles/${slug}.json`);
-      const json: Article = await response.json();
-      // update only the found article
+      const article = await fetchV2(`data:articles/:slug.json`, { params: { slug } });
       dispatch({
         type: "UPDATE_ARTICLES_SCREEN",
         payload: {
-          articles: articles?.map((article) => (article.slug === slug ? json : article)),
+          // update only the found article
+          articles: articles?.map((a) => (a.slug === slug ? article : a)),
           refreshing: false,
         },
       });

--- a/mobile/src/redux/actions/articles-screen/index.ts
+++ b/mobile/src/redux/actions/articles-screen/index.ts
@@ -1,6 +1,7 @@
 import { Article } from "../../../_common/types";
 import { ArticlesScreenState } from "../../reducers/articles-screen";
 import { ThunkResult } from "../..";
+import { fetchV2 } from "../../../utils/fetch";
 import { fullstackConfig } from "../../../config";
 
 const dataURL = fullstackConfig.data.url;
@@ -15,12 +16,11 @@ export const fetchArticles = (): ThunkResult<ArticlesScreenState> => async (disp
     payload: { refreshing: true },
   });
   try {
-    const response = await fetch(`${dataURL}/articles/list.c.json`);
-    const json: Article[] = await response.json();
+    const articles = await fetchV2("data:articles/list.c.json", {});
     dispatch({
       type: "UPDATE_ARTICLES_SCREEN",
       payload: {
-        articles: json,
+        articles,
         refreshing: false,
       },
     });

--- a/mobile/src/redux/actions/contribute-screen/index.ts
+++ b/mobile/src/redux/actions/contribute-screen/index.ts
@@ -1,10 +1,7 @@
 import { ContributeScreenState } from "../../reducers/contribute-screen";
 import Debounce from "debounce";
-import { GetContributionsResponseDto } from "../../../_common/types/api-responses";
 import { ThunkResult } from "../..";
-import { fullstackConfig } from "../../../config";
-
-const apiURL = fullstackConfig.api.url;
+import { fetchV2 } from "../../../utils/fetch";
 
 /**
  * @function fetchContributions
@@ -18,15 +15,13 @@ export const fetchContributions =
     });
     try {
       const { contributeScreen } = getState();
-      const query = contributeScreen.filters.reduce(
-        (query, filter) =>
-          `${query}${filter.name}=${filter.options
-            .filter(({ checked }) => checked)
-            .reduce((filterQuery, option) => `${filterQuery}${option.name},`, "")}&`,
-        "?",
-      );
-      const response = await fetch(apiURL + "/v2/Contributions" + query);
-      const { contributions, filters }: GetContributionsResponseDto = await response.json();
+      const query: [string, string][] = [];
+      contributeScreen.filters.forEach((filter) => {
+        filter.options.forEach((option) => {
+          if (option.checked) query.push([filter.name, option.name]);
+        });
+      });
+      const { contributions, filters } = await fetchV2("api:v2/Contributions", { query });
 
       const checkedFilters: Array<{
         filterName: string;

--- a/mobile/src/redux/actions/contribute-screen/index.ts
+++ b/mobile/src/redux/actions/contribute-screen/index.ts
@@ -1,6 +1,6 @@
 import { ContributeScreenState } from "../../reducers/contribute-screen";
 import Debounce from "debounce";
-import { GetContributionsResponseDto } from "../../../.common/types/api-responses";
+import { GetContributionsResponseDto } from "../../../_common/types/api-responses";
 import { ThunkResult } from "../..";
 import { fullstackConfig } from "../../../config";
 

--- a/mobile/src/redux/reducers/articles-screen/index.ts
+++ b/mobile/src/redux/reducers/articles-screen/index.ts
@@ -1,5 +1,5 @@
 import { Action } from "../..";
-import { Article } from "../../../.common/types";
+import { Article } from "../../../_common/types";
 
 export interface ArticlesScreenState {
   articles: Article[] | null;

--- a/mobile/src/redux/reducers/contribute-screen/index.ts
+++ b/mobile/src/redux/reducers/contribute-screen/index.ts
@@ -1,4 +1,4 @@
-import { ContributionEntity, FilterEntity } from "../../../.common/types";
+import { ContributionEntity, FilterEntity } from "../../../_common/types";
 import { Action } from "../..";
 
 export interface ContributeScreenState {

--- a/mobile/src/screens/articles/article-details/index.tsx
+++ b/mobile/src/screens/articles/article-details/index.tsx
@@ -2,7 +2,7 @@ import { Dispatch, StateInterface } from "../../../redux";
 import { Image, ScrollView, View } from "react-native";
 import React, { FC, useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { Article } from "../../../.common/types";
+import { Article } from "../../../_common/types";
 import { ArticlesScreenState } from "../../../redux/reducers/articles-screen";
 import { DZCodeLoading } from "../../../components/loading";
 import { GeneralState } from "../../../redux/reducers/general";

--- a/mobile/src/screens/contribute/card-item/index.tsx
+++ b/mobile/src/screens/contribute/card-item/index.tsx
@@ -1,11 +1,11 @@
 import { Badge, Button, Card, Chip, Paragraph, Text, Title } from "react-native-paper";
 import React, { FC, memo } from "react";
 import { Colors } from "../../../styles/colors";
-import { ContributionEntity } from "../../../.common/types";
+import { ContributionEntity } from "../../../_common/types";
 import { FlatList } from "react-native";
 import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
 import { View } from "react-native";
-import { calculateDate } from "../../../.common/utils/calculate-date";
+import { calculateDate } from "../../../_common/utils/calculate-date";
 import { cardStyles } from "./styles";
 
 interface CardItemProps

--- a/mobile/src/utils/fetch/endpoints.ts
+++ b/mobile/src/utils/fetch/endpoints.ts
@@ -1,0 +1,8 @@
+import { GetContributionsResponseDto } from "../../_common/types/api-responses";
+
+export interface Endpoints {
+  "api:v2/Contributions": {
+    response: GetContributionsResponseDto;
+    query: [string, string][];
+  };
+}

--- a/mobile/src/utils/fetch/endpoints.ts
+++ b/mobile/src/utils/fetch/endpoints.ts
@@ -5,6 +5,10 @@ export interface Endpoints {
   "data:articles/list.c.json": {
     response: Article[]; // TODO-ZM: should be: Pick<Article, "title">[] instead
   };
+  "data:articles/:slug.json": {
+    response: Article;
+    params: { slug: string };
+  };
   "api:v2/Contributions": {
     response: GetContributionsResponseDto;
     query: [string, string][];

--- a/mobile/src/utils/fetch/endpoints.ts
+++ b/mobile/src/utils/fetch/endpoints.ts
@@ -1,6 +1,10 @@
+import { Article } from "../../_common/types";
 import { GetContributionsResponseDto } from "../../_common/types/api-responses";
 
 export interface Endpoints {
+  "data:articles/list.c.json": {
+    response: Article[]; // TODO-ZM: should be: Pick<Article, "title">[] instead
+  };
   "api:v2/Contributions": {
     response: GetContributionsResponseDto;
     query: [string, string][];

--- a/mobile/src/utils/fetch/index.ts
+++ b/mobile/src/utils/fetch/index.ts
@@ -20,7 +20,15 @@ export const fetchV2 = async <
 
   const queryString = query ? "?" + query.map(([key, value]) => `${key}=${value}`).join("&") : "";
 
-  const [domain, url] = (endpoint as string).split(":", 2);
+  const domain = (endpoint as string).slice(0, (endpoint as string).indexOf(":"));
+  let url = (endpoint as string).slice(domain.length + 1);
+
+  if (params) {
+    Object.keys(params).forEach((param) => {
+      url = url.replace(`:${param}`, params[param]);
+    });
+  }
+
   let baseURL = "";
 
   switch (domain) {

--- a/mobile/src/utils/fetch/index.ts
+++ b/mobile/src/utils/fetch/index.ts
@@ -1,0 +1,36 @@
+import { Endpoints } from "./endpoints";
+import { fullstackConfig } from "../../config";
+
+interface Endpoint {
+  params?: Record<string, string>;
+  query?: [string, string][];
+  body?: never;
+}
+
+export const fetchV2 = async <
+  T extends Endpoints,
+  E extends keyof T,
+  C extends T[E],
+  D extends keyof C,
+>(
+  endpoint: E,
+  config: Pick<C, Exclude<D, "response">>,
+): Promise<C[D & "response"]> => {
+  const { body, params, query } = config as Endpoint;
+
+  const queryString = query ? "?" + query.map(([key, value]) => `${key}=${value}`).join("&") : "";
+
+  const [domain, url] = (endpoint as string).split(":", 2);
+  let baseURL = "";
+
+  switch (domain) {
+    case "data":
+      baseURL = fullstackConfig.data.url;
+      break;
+    case "api":
+      baseURL = fullstackConfig.api.url;
+      break;
+  }
+  const response = await fetch(`${baseURL}/${url}${queryString}`, { body });
+  return (await response.json()) as C[D & "response"];
+};


### PR DESCRIPTION
# Description

A third round of refactoring that resolves #362 , which adds a typed wrapper around `fetch`. Also renamed the auto-generated `.common` folder  to `_common` due to caching problems with Metro

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Refactoring
