### PR TITLE
Fix: use `exec` instead of `run` when running `lint-staged`

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
       "syncpack format"
     ],
     "./*.*": [
-      "yarn prettier --config ./packages/tooling/.prettierrc --ignore-path ./packages/tooling/.prettierignore --loglevel warn --write"
+      "prettier --config ./packages/tooling/.prettierrc --ignore-path ./packages/tooling/.prettierignore --loglevel warn --write"
     ]
   },
   "private": true,
@@ -34,7 +34,8 @@
     "dev:web": "yarn dev:all --scope=@dzcode.io/{web,api,data}",
     "lint": "yarn build && yarn lint:alone",
     "lint:alone": "lerna run lint:alone --stream",
-    "postinstall": "(husky install && husky set .husky/pre-commit \"yarn lerna run lint-staged --since HEAD && yarn lint-staged\") || exit 0",
+    "lint:staged": "lerna exec --since HEAD -- lint-staged && lint-staged",
+    "postinstall": "(husky install && husky set .husky/pre-commit \"yarn lint:staged\") || exit 0",
     "start:dev": "lerna run start:dev --parallel",
     "test": "yarn build && yarn test:alone",
     "test:alone": "lerna run test:alone --stream"

--- a/packages/models/src/language/index.spec.ts
+++ b/packages/models/src/language/index.spec.ts
@@ -1,4 +1,4 @@
-import { allLanguages, LanguageEntity } from ".";
+import { LanguageEntity, allLanguages } from ".";
 import { runDTOTestCases } from "../_test";
 
 runDTOTestCases(


### PR DESCRIPTION
# Description

turns out the lint-staged was ignored since #424 , this should fix that

## Type of change

<!-- Please delete options that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)
