### PR TITLE
Feat: Migrate `react-native-markdown-display` to `@dzcode.io/ui-mobile`

### DIFF
--- a/mobile/package.json
+++ b/mobile/package.json
@@ -33,7 +33,6 @@
     "react-native": "0.68.2",
     "react-native-appearance": "~0.3.3",
     "react-native-gesture-handler": "~2.2.1",
-    "react-native-markdown-display": "^7.0.0-alpha.2",
     "react-native-reanimated": "~2.8.0",
     "react-native-safe-area-context": "4.2.4",
     "react-native-screens": "~3.11.1",

--- a/mobile/src/screens/articles/article-details/index.tsx
+++ b/mobile/src/screens/articles/article-details/index.tsx
@@ -2,13 +2,13 @@ import { Article } from "@dzcode.io/api/dist/app/types/legacy";
 import { ErrorBoundary } from "@dzcode.io/ui-mobile/dist/error-boundary";
 import { useNavigation } from "@dzcode.io/ui-mobile/dist/hooks";
 import { DZCodeLoading } from "@dzcode.io/ui-mobile/dist/loading";
+import { Markdown } from "@dzcode.io/ui-mobile/dist/markdown";
 import { Text } from "@dzcode.io/ui-mobile/dist/text";
 import { TryAgain } from "@dzcode.io/ui-mobile/dist/try-again";
 import { RouteParam } from "@dzcode.io/ui-mobile/dist/types";
 import { isLoaded } from "@dzcode.io/utils/dist/loadable";
 import React, { FC, useEffect } from "react";
 import { Image, SafeAreaView, ScrollView, View } from "react-native";
-import Markdown from "react-native-markdown-display";
 import { useDispatch } from "react-redux";
 import { AppDispatch } from "src/redux";
 import { fetchArticle } from "src/redux/actions/articles-screen";
@@ -60,39 +60,10 @@ export const ArticleDetailsScreen: FC<ArticleDetailsScreenProps> = ({
             <Text style={articleDetailsStyles.authorsText}>{route.params.article.title}</Text>
             <Text style={articleDetailsStyles.descriptionText}>{currentArticle.description}</Text>
             <Markdown
-              style={{
-                text: {
-                  color: theme === "dark" ? "white" : "black",
-                },
-                /* eslint-disable camelcase */
-                bullet_list: {
-                  color: theme === "dark" ? "white" : "black",
-                },
-                ordered_list: {
-                  color: theme === "dark" ? "white" : "black",
-                },
-                fence: {
-                  color: theme === "dark" ? "white" : "black",
-                  backgroundColor: theme === "dark" ? "black" : "white",
-                },
-                blockquote: {
-                  color: theme === "dark" ? "white" : "black",
-                  backgroundColor: theme === "dark" ? "black" : "white",
-                },
-                code_inline: {
-                  color: theme === "dark" ? "white" : "black",
-                  backgroundColor: theme === "dark" ? "black" : "white",
-                },
-                body: articleDetailsStyles.mdBody,
-                /* eslint-enable camelcase */
-              }}
-              onLinkPress={(url) => {
-                openLink(url, navigation);
-                return true;
-              }}
-            >
-              {currentArticle.content}
-            </Markdown>
+              content={currentArticle.content!}
+              theme={theme}
+              onLinkPress={(url) => openLink(url, navigation)}
+            />
             <Text style={articleDetailsStyles.authorsText}>
               Authors: {currentArticle.authors?.join(", ")}
             </Text>

--- a/mobile/src/screens/learn/document-details/index.tsx
+++ b/mobile/src/screens/learn/document-details/index.tsx
@@ -1,19 +1,20 @@
 import { Document } from "@dzcode.io/api/dist/app/types/legacy";
 import { ErrorBoundary } from "@dzcode.io/ui-mobile/dist/error-boundary";
 import { DZCodeLoading } from "@dzcode.io/ui-mobile/dist/loading";
+import { Markdown } from "@dzcode.io/ui-mobile/dist/markdown";
 import { Text } from "@dzcode.io/ui-mobile/dist/text";
 import { TryAgain } from "@dzcode.io/ui-mobile/dist/try-again";
 import { RouteParam } from "@dzcode.io/ui-mobile/dist/types";
 import { isLoaded } from "@dzcode.io/utils/dist/loadable";
 import React, { FC, useEffect } from "react";
 import { Image, SafeAreaView, ScrollView, View } from "react-native";
-import Markdown from "react-native-markdown-display";
 import { useDispatch } from "react-redux";
 import { AppDispatch } from "src/redux";
 import { fetchDocument } from "src/redux/actions/learn-screen";
 import { useGeneralSliceSelector } from "src/redux/reducers/general/slice";
 import { useLearnSliceSelector } from "src/redux/reducers/learn-screen/slice";
 import { globalStyles } from "src/styles/global";
+import { openLink } from "src/utils/link";
 
 import { documentDetailsStyles } from "./styles";
 
@@ -55,35 +56,10 @@ export const DocumentDetailsScreen: FC<DocumentDetailsScreenProps> = ({
             <Text style={documentDetailsStyles.authorsText}>{route.params.document.title}</Text>
             <Text style={documentDetailsStyles.descriptionText}>{currentDocument.description}</Text>
             <Markdown
-              style={{
-                text: {
-                  color: theme === "dark" ? "white" : "black",
-                },
-                /* eslint-disable camelcase */
-                bullet_list: {
-                  color: theme === "dark" ? "white" : "black",
-                },
-                ordered_list: {
-                  color: theme === "dark" ? "white" : "black",
-                },
-                fence: {
-                  color: theme === "dark" ? "white" : "black",
-                  backgroundColor: theme === "dark" ? "black" : "white",
-                },
-                blockquote: {
-                  color: theme === "dark" ? "white" : "black",
-                  backgroundColor: theme === "dark" ? "black" : "white",
-                },
-                code_inline: {
-                  color: theme === "dark" ? "white" : "black",
-                  backgroundColor: theme === "dark" ? "black" : "white",
-                },
-                body: documentDetailsStyles.mdBody,
-                /* eslint-enable camelcase */
-              }}
-            >
-              {currentDocument.content}
-            </Markdown>
+              content={currentDocument.content!}
+              theme={theme}
+              onLinkPress={(url) => openLink(url)}
+            />
             <Text style={documentDetailsStyles.authorsText}>
               Authors: {currentDocument.authors?.join(", ")}
             </Text>

--- a/packages/ui-mobile/package.json
+++ b/packages/ui-mobile/package.json
@@ -8,6 +8,7 @@
     "url": "https://omar-belghaouti.web.app"
   },
   "dependencies": {
+    "@expo-google-fonts/roboto": "^0.2.2",
     "@react-navigation/bottom-tabs": "5.11.2",
     "@react-navigation/drawer": "^5.12.5",
     "@react-navigation/native": "~5.8.10",

--- a/packages/ui-mobile/src/loading/index.tsx
+++ b/packages/ui-mobile/src/loading/index.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useState } from "react";
+import React, { useEffect, useState, VFC } from "react";
 import { Animated, ImageStyle } from "react-native";
 
 import { dzcodeLoadingStyles } from "./styles";
@@ -7,7 +7,7 @@ interface DZCodeLoadingProps {
   style?: ImageStyle;
 }
 
-export const DZCodeLoading: FC<DZCodeLoadingProps> = ({ style }: DZCodeLoadingProps) => {
+export const DZCodeLoading: VFC<DZCodeLoadingProps> = ({ style }: DZCodeLoadingProps) => {
   const [rotateAnimValue, setRotateAnimValue] = useState(new Animated.Value(0));
 
   useEffect(() => {

--- a/packages/ui-mobile/src/markdown/index.test.tsx
+++ b/packages/ui-mobile/src/markdown/index.test.tsx
@@ -1,0 +1,11 @@
+import { render } from "@testing-library/react-native";
+import React from "react";
+
+import { Markdown } from ".";
+
+describe("Markdown", () => {
+  it("should render", () => {
+    const { container } = render(<Markdown content="# Test" />);
+    expect(container).toBeTruthy();
+  });
+});

--- a/packages/ui-mobile/src/markdown/index.tsx
+++ b/packages/ui-mobile/src/markdown/index.tsx
@@ -1,5 +1,8 @@
+import { Roboto_400Regular, Roboto_700Bold, useFonts } from "@expo-google-fonts/roboto";
 import React, { VFC } from "react";
+import { View } from "react-native";
 import { default as MarkdownDisplay, MarkdownIt } from "react-native-markdown-display";
+import { DZCodeLoading } from "src/loading";
 import { LARGE_MARGIN_SIZE } from "src/utils/constants";
 
 interface MarkdownProps {
@@ -9,43 +12,66 @@ interface MarkdownProps {
 }
 
 export const Markdown: VFC<MarkdownProps> = ({ content, theme = "light", onLinkPress }) => {
-  return (
-    <MarkdownDisplay
-      markdownit={MarkdownIt({ typographer: true, linkify: true })}
-      style={{
-        text: {
-          color: theme === "dark" ? "white" : "black",
-        },
-        /* eslint-disable camelcase */
-        bullet_list: {
-          color: theme === "dark" ? "white" : "black",
-        },
-        ordered_list: {
-          color: theme === "dark" ? "white" : "black",
-        },
-        fence: {
-          color: theme === "dark" ? "white" : "black",
-          backgroundColor: "transparent",
-        },
-        blockquote: {
-          color: theme === "dark" ? "white" : "black",
-          backgroundColor: "transparent",
-        },
-        code_inline: {
-          color: theme === "dark" ? "white" : "black",
-          backgroundColor: "transparent",
-        },
-        body: {
-          marginHorizontal: LARGE_MARGIN_SIZE,
-        },
-        /* eslint-enable camelcase */
-      }}
-      onLinkPress={(url) => {
-        onLinkPress?.(url);
-        return true;
-      }}
-    >
-      {content}
-    </MarkdownDisplay>
-  );
+  const [fontsLoaded] = useFonts({
+    Roboto_400Regular,
+    Roboto_700Bold,
+  });
+
+  if (!fontsLoaded) {
+    return (
+      <View
+        style={{
+          flex: 1,
+          justifyContent: "center",
+          alignItems: "center",
+        }}
+      >
+        <DZCodeLoading />
+      </View>
+    );
+  } else {
+    return (
+      <MarkdownDisplay
+        markdownit={MarkdownIt({ typographer: true, linkify: true })}
+        style={{
+          text: {
+            color: theme === "dark" ? "white" : "black",
+          },
+          /* eslint-disable camelcase */
+          bullet_list: {
+            color: theme === "dark" ? "white" : "black",
+          },
+          ordered_list: {
+            color: theme === "dark" ? "white" : "black",
+          },
+          fence: {
+            color: theme === "dark" ? "white" : "black",
+            backgroundColor: "transparent",
+            fontFamily: "Roboto_400Regular",
+          },
+          blockquote: {
+            color: theme === "dark" ? "white" : "black",
+            backgroundColor: "transparent",
+            fontFamily: "Roboto_400Regular",
+          },
+          code_inline: {
+            color: theme === "dark" ? "white" : "black",
+            backgroundColor: "transparent",
+            fontFamily: "Roboto_400Regular",
+          },
+          body: {
+            marginHorizontal: LARGE_MARGIN_SIZE,
+            fontFamily: "Roboto_400Regular",
+          },
+          /* eslint-enable camelcase */
+        }}
+        onLinkPress={(url) => {
+          onLinkPress?.(url);
+          return true;
+        }}
+      >
+        {content}
+      </MarkdownDisplay>
+    );
+  }
 };

--- a/packages/ui-mobile/src/markdown/index.tsx
+++ b/packages/ui-mobile/src/markdown/index.tsx
@@ -1,0 +1,51 @@
+import React, { VFC } from "react";
+import { default as MarkdownDisplay, MarkdownIt } from "react-native-markdown-display";
+import { LARGE_MARGIN_SIZE } from "src/utils/constants";
+
+interface MarkdownProps {
+  content: string;
+  theme?: "dark" | "light";
+  onLinkPress?: (url: string) => void;
+}
+
+export const Markdown: VFC<MarkdownProps> = ({ content, theme = "light", onLinkPress }) => {
+  return (
+    <MarkdownDisplay
+      markdownit={MarkdownIt({ typographer: true, linkify: true })}
+      style={{
+        text: {
+          color: theme === "dark" ? "white" : "black",
+        },
+        /* eslint-disable camelcase */
+        bullet_list: {
+          color: theme === "dark" ? "white" : "black",
+        },
+        ordered_list: {
+          color: theme === "dark" ? "white" : "black",
+        },
+        fence: {
+          color: theme === "dark" ? "white" : "black",
+          backgroundColor: "transparent",
+        },
+        blockquote: {
+          color: theme === "dark" ? "white" : "black",
+          backgroundColor: "transparent",
+        },
+        code_inline: {
+          color: theme === "dark" ? "white" : "black",
+          backgroundColor: "transparent",
+        },
+        body: {
+          marginHorizontal: LARGE_MARGIN_SIZE,
+        },
+        /* eslint-enable camelcase */
+      }}
+      onLinkPress={(url) => {
+        onLinkPress?.(url);
+        return true;
+      }}
+    >
+      {content}
+    </MarkdownDisplay>
+  );
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2289,6 +2289,11 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@expo-google-fonts/roboto@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@expo-google-fonts/roboto/-/roboto-0.2.2.tgz#0a9f4685e8d02bdb0d2d2919c102f531bdb353d4"
+  integrity sha512-qP0oZsR8rTID5T9wEXSt9yCYMnKYKlvIlrJGGpd+t71Obt2J51+51PBpvxd5c8fpABEru3zx6ENmpU9lzwr8zw==
+
 "@expo/apple-utils@0.0.0-alpha.31":
   version "0.0.0-alpha.31"
   resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-0.0.0-alpha.31.tgz#ab18640c384ba4b088e4490977a12f6f41a1e2a0"
@@ -8393,9 +8398,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001272, caniuse-lite@^1.0.30001280, caniuse-lite@^1.0.30001359, caniuse-lite@^1.0.30001370:
-  version "1.0.30001402"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001402.tgz#aa29e1f47f5055b0d0c07696a67b8b08023d14c8"
-  integrity sha512-Mx4MlhXO5NwuvXGgVb+hg65HZ+bhUYsz8QtDGDo2QmaJS2GBX47Xfi2koL86lc8K+l+htXeTEB/Aeqvezoo6Ew==
+  version "1.0.30001414"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001414.tgz#5f1715e506e71860b4b07c50060ea6462217611e"
+  integrity sha512-t55jfSaWjCdocnFdKQoO+d2ct9C59UZg4dY3OnUlSZ447r8pUtIKdp0hpAzrGFultmTC+Us+KpKi4GZl/LXlFg==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
# Description

This PR is dedicated to migrate `react-native-markdown-display` from `./mobile` to `@dzcode.io/ui-mobile`

Resolves #505 

## Type of change

- New feature (non-breaking change which adds functionality)
