### PR TITLE
Chore: add `ui-mobile` label to `labeler.yml`

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -42,3 +42,7 @@ tooling:
 # Add 'ui' to any changes within 'ui' folder or any subfolders
 ui:
   - packages/ui/**/*
+
+# Add 'ui-mobile' to any changes within 'ui-mobile' folder or any subfolders
+ui-mobile:
+  - packages/ui-mobile/**/*


### PR DESCRIPTION
# Description

This PR is dedicated to add the `ui-mobile` label in CI automatically whenever change happens to `./packages/ui-mobile`

Resolves #515 

## Type of change

- New feature (non-breaking change which adds functionality)
