### PR TITLE
Fix: landing page UI migration bugs

### DIFF
--- a/packages/ui/src/v2/dropdown/index.tsx
+++ b/packages/ui/src/v2/dropdown/index.tsx
@@ -22,9 +22,11 @@ export const Dropdown = <C extends string>({
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
 
-  const handleClose = (code: C) => {
+  const handleClose = (code?: C) => {
     setAnchorEl(null);
-    onSelect?.(code);
+    if (code) {
+      onSelect?.(code);
+    }
   };
   return (
     <>

--- a/packages/ui/src/v2/dropdown/index.tsx
+++ b/packages/ui/src/v2/dropdown/index.tsx
@@ -32,7 +32,7 @@ export const Dropdown = <C extends string>({
         {text}
       </Button>
       <GlobalStyles styles="ul { padding: 0 !important; }" />
-      <Menu anchorEl={anchorEl} open={open} onClose={handleClose}>
+      <Menu anchorEl={anchorEl} open={open} onClose={() => handleClose()}>
         <Stack direction="vertical">
           {items.map((item, index) => (
             <MenuItem key={`item-${index}`} onClick={() => handleClose(item.code)}>

--- a/web/src/_entry/app.tsx
+++ b/web/src/_entry/app.tsx
@@ -59,6 +59,7 @@ const routes: RouteInterface[] = [
 export const App: FC = () => {
   const location = useLocation();
   const match = useRouteMatch<{ lang?: LanguageEntity["code"] }>(urlLanguageRegEx);
+  const landingPageMatch = useRouteMatch<{ lang?: LanguageEntity["code"] }>(`${urlLanguageRegEx}/`);
   const { language, themeName } = useSliceSelector("settings");
   const { links } = useSliceSelector("navbarComponent");
   const { sections } = useSliceSelector("footerComponent");
@@ -99,7 +100,7 @@ export const App: FC = () => {
           onThemeChanged={(selectedThemeName) => {
             actions.settings.set({ themeName: selectedThemeName });
           }}
-          fixed={location.pathname === "/"}
+          fixed={!!landingPageMatch?.isExact}
         />
         <Flex max={{ width: MAX_CONTAINER_WIDTH }}>
           <Suspense fallback={<Loading />}>


### PR DESCRIPTION
# Description

fixed two bugs:

- closing the theme dropdown without selecting a theme will cause the them to revert to light and the dropdown to have no theme selected.
- landing page header text is not center-aligned vertically when switching to Arabic

these are regressions of #489 

## Type of change

- Bug fix (non-breaking change which fixes an issue)
