### PR TITLE
feat: move projects endpoint from `./data` to `./api`

### DIFF
--- a/api/src/app/index.ts
+++ b/api/src/app/index.ts
@@ -11,6 +11,7 @@ import { GithubController } from "src/github/controller";
 import { GithubUserController } from "src/github-user/controller";
 import { LoggerService } from "src/logger/service";
 import { MilestoneController } from "src/milestone/controller";
+import { ProjectController } from "src/project/controller";
 import { TeamController } from "src/team/controller";
 import Container from "typedi";
 
@@ -46,6 +47,7 @@ export const routingControllersOptions: RoutingControllersOptions = {
     TeamController,
     GithubController,
     MilestoneController,
+    ProjectController,
   ],
   middlewares: [
     SentryRequestHandlerMiddleware,

--- a/api/src/contributor/controller.ts
+++ b/api/src/contributor/controller.ts
@@ -23,13 +23,13 @@ export class ContributorController {
       // current place for data:
       this.githubService.listContributors({
         owner: "dzcode-io",
-        repo: "dzcode.io",
+        repository: "dzcode.io",
         path: `data/models/${path}`,
       }),
       // also check old place for data, to not lose contribution effort:
       this.githubService.listContributors({
         owner: "dzcode-io",
-        repo: "dzcode.io",
+        repository: "dzcode.io",
         path: `data/${path}`,
       }),
     ]);

--- a/api/src/data/service.ts
+++ b/api/src/data/service.ts
@@ -1,0 +1,25 @@
+import { getCollection } from "@dzcode.io/data/dist/get/collection";
+import { join } from "path";
+import { ConfigService } from "src/config/service";
+import { Service } from "typedi";
+
+import { ProjectReferenceEntity } from "./types";
+
+@Service()
+export class DataService {
+  constructor(private readonly configService: ConfigService) {}
+
+  public listProjects = async (): Promise<ProjectReferenceEntity[]> => {
+    const projects = getCollection<ProjectReferenceEntity>(
+      this.dataModelsPath,
+      "projects-v2",
+      "list.json",
+    );
+
+    if (projects === 404) throw new Error("Projects list not found");
+
+    return projects;
+  };
+
+  private dataModelsPath = join(__dirname, "../../../data");
+}

--- a/api/src/data/types.ts
+++ b/api/src/data/types.ts
@@ -1,0 +1,7 @@
+import { Model } from "@dzcode.io/models/dist/_base";
+import { ProjectEntity } from "@dzcode.io/models/dist/project";
+import { RepositoryEntity } from "@dzcode.io/models/dist/repository";
+
+export interface ProjectReferenceEntity extends Model<ProjectEntity> {
+  repositories: Model<RepositoryEntity>[];
+}

--- a/api/src/github/service.spec.ts
+++ b/api/src/github/service.spec.ts
@@ -9,7 +9,7 @@ import { GeneralGithubQuery, ListContributorsResponse } from "./types";
 describe("GithubService", () => {
   const githubQuery: GeneralGithubQuery = {
     owner: "test-owner",
-    repo: "test-repo",
+    repository: "test-repo",
     path: "test/path",
   };
   const contributorsMock: ListContributorsResponse = [

--- a/api/src/github/service.ts
+++ b/api/src/github/service.ts
@@ -24,11 +24,11 @@ export class GithubService {
 
   public listContributors = async ({
     owner,
-    repo,
+    repository,
     path,
   }: GeneralGithubQuery): Promise<GithubUser[]> => {
     const commits = await this.fetchService.get<ListContributorsResponse>(
-      `${this.apiURL}/repos/${owner}/${repo}/commits`,
+      `${this.apiURL}/repos/${owner}/${repository}/commits`,
       {
         headers: this.githubToken ? { Authorization: `Token ${this.githubToken}` } : {},
         params: { path, state: "all", per_page: 100 }, // eslint-disable-line camelcase
@@ -58,10 +58,10 @@ export class GithubService {
 
   public listRepositoryIssues = async ({
     owner,
-    repo,
+    repository,
   }: GitHubListRepositoryIssuesInput): Promise<GithubIssue[]> => {
     const issues = await this.fetchService.get<GithubIssue[]>(
-      `${this.apiURL}/repos/${owner}/${repo}/issues`,
+      `${this.apiURL}/repos/${owner}/${repository}/issues`,
       {
         headers: this.githubToken ? { Authorization: `Token ${this.githubToken}` } : {},
         params: { sort: "updated", per_page: 100 }, // eslint-disable-line camelcase
@@ -72,10 +72,10 @@ export class GithubService {
 
   public listRepositoryLanguages = async ({
     owner,
-    repo,
+    repository,
   }: GitHubListRepositoryLanguagesInput): Promise<string[]> => {
     const languages = await this.fetchService.get<Record<string, number>>(
-      `${this.apiURL}/repos/${owner}/${repo}/languages`,
+      `${this.apiURL}/repos/${owner}/${repository}/languages`,
       { headers: this.githubToken ? { Authorization: `Token ${this.githubToken}` } : {} },
     );
     return Object.keys(languages);
@@ -83,17 +83,22 @@ export class GithubService {
 
   public listRepositoryContributors = async ({
     owner,
-    repo,
+    repository,
   }: Omit<GeneralGithubQuery, "path">): Promise<ListRepositoryContributorsResponse> => {
     const contributors = await this.fetchService.get<ListRepositoryContributorsResponse>(
-      `${this.apiURL}/repos/${owner}/${repo}/contributors`,
+      `${this.apiURL}/repos/${owner}/${repository}/contributors`,
       {
         headers: this.githubToken ? { Authorization: `Token ${this.githubToken}` } : {},
         params: { state: "all", per_page: 100 }, // eslint-disable-line camelcase
       },
     );
 
-    return contributors.filter(({ type }) => type === "User");
+    return (
+      contributors
+        // @TODO-ZM: filter out bots
+        .filter(({ type }) => type === "User")
+        .sort((a, b) => b.contributions - a.contributions)
+    );
   };
 
   public getRateLimit = async (): Promise<{ limit: number; used: number; ratio: number }> => {
@@ -111,10 +116,10 @@ export class GithubService {
 
   public listRepositoryMilestones = async ({
     owner,
-    repo,
+    repository,
   }: GitHubListRepositoryMilestonesInput): Promise<GithubMilestone[]> => {
     const milestones = await this.fetchService.get<GithubMilestone[]>(
-      `${this.apiURL}/repos/${owner}/${repo}/milestones`,
+      `${this.apiURL}/repos/${owner}/${repository}/milestones`,
       {
         headers: this.githubToken ? { Authorization: `Token ${this.githubToken}` } : {},
         params: { state: "all", per_page: 100 }, // eslint-disable-line camelcase

--- a/api/src/github/types.ts
+++ b/api/src/github/types.ts
@@ -10,7 +10,7 @@ export type ListRepositoryContributorsResponse = Array<GithubUser & { contributi
 
 export interface GeneralGithubQuery {
   owner: string;
-  repo: string;
+  repository: string;
   path: string;
 }
 
@@ -55,7 +55,7 @@ export interface GitHubUserApiResponse {
 
 export interface GitHubListRepositoryIssuesInput {
   owner: string;
-  repo: string;
+  repository: string;
 }
 
 export type GitHubListRepositoryLanguagesInput = GitHubListRepositoryIssuesInput;

--- a/api/src/milestone/controller.ts
+++ b/api/src/milestone/controller.ts
@@ -12,13 +12,13 @@ export class MilestoneController {
 
   @Get("/dzcode")
   @OpenAPI({
-    summary: "Return a list of milestones for all dzcode.io repo",
+    summary: "Return a list of milestones for dzcode.io repository",
   })
   @ResponseSchema(GetMilestonesResponseDto)
   public async getMilestones(): Promise<GetMilestonesResponseDto> {
     const githubMilestones = await this.githubService.listRepositoryMilestones({
       owner: "dzcode-io",
-      repo: "dzcode.io",
+      repository: "dzcode.io",
     });
     return {
       milestones: githubMilestones

--- a/api/src/project/controller.ts
+++ b/api/src/project/controller.ts
@@ -1,0 +1,68 @@
+import { Controller, Get } from "routing-controllers";
+import { OpenAPI, ResponseSchema } from "routing-controllers-openapi";
+import { DataService } from "src/data/service";
+import { GithubService } from "src/github/service";
+import { Service } from "typedi";
+
+import { GetProjectsResponseDto } from "./types";
+
+@Service()
+@Controller("/Projects")
+export class ProjectController {
+  constructor(
+    private readonly githubService: GithubService,
+    private readonly dataService: DataService,
+  ) {}
+
+  @Get("/")
+  @OpenAPI({
+    summary: "Return all projects listed in dzcode.io website",
+  })
+  @ResponseSchema(GetProjectsResponseDto)
+  public async getProjects(): Promise<GetProjectsResponseDto> {
+    // get projects from /data folder:
+    const projects = await this.dataService.listProjects();
+
+    // fetch info about these projects from github:
+    const infoRichProjects: GetProjectsResponseDto["projects"] = await Promise.all(
+      projects.map(async (project) => {
+        const { repositories } = project;
+        return {
+          ...project,
+          repositories: await Promise.all(
+            repositories.map(async ({ provider, owner, repository }) => {
+              return {
+                provider,
+                owner,
+                repository,
+                stats: {
+                  contributionCount: (
+                    await this.githubService.listRepositoryIssues({ owner, repository })
+                  ).length,
+                  languages: await this.githubService.listRepositoryLanguages({
+                    owner,
+                    repository,
+                  }),
+                },
+                contributors: (
+                  await this.githubService.listRepositoryContributors({
+                    owner,
+                    repository,
+                  })
+                ).map((contributor) => ({
+                  id: `github/${contributor.id}`,
+                  username: contributor.login,
+                  avatarUrl: contributor.avatar_url,
+                })),
+              };
+            }),
+          ),
+        };
+      }),
+    );
+
+    return {
+      projects: infoRichProjects,
+    };
+  }
+}

--- a/api/src/project/types.ts
+++ b/api/src/project/types.ts
@@ -1,5 +1,6 @@
 import { Model } from "@dzcode.io/models/dist/_base";
 import { ProjectEntity } from "@dzcode.io/models/dist/project";
+import { RepositoryEntity } from "@dzcode.io/models/dist/repository";
 import { Type } from "class-transformer";
 import { ValidateNested } from "class-validator";
 import { GeneralResponseDto } from "src/app/types";
@@ -7,5 +8,9 @@ import { GeneralResponseDto } from "src/app/types";
 export class GetProjectsResponseDto extends GeneralResponseDto {
   @ValidateNested({ each: true })
   @Type(() => ProjectEntity)
-  projects!: Model<ProjectEntity, "repositories">[];
+  // @TODO-ZM: find a way to DRY this, eg:
+  // projects!: Model<ProjectEntity, 'repositories' | 'repositories.contributors' | 'repositories.stats'>[]
+  projects!: Array<
+    Model<ProjectEntity> & { repositories: Model<RepositoryEntity, "contributors" | "stats">[] }
+  >;
 }

--- a/packages/models/src/contributor/__snapshots__/index.spec.ts.snap
+++ b/packages/models/src/contributor/__snapshots__/index.spec.ts.snap
@@ -5,7 +5,7 @@ exports[`should match snapshot when providing all fields: errors 1`] = `Array []
 exports[`should match snapshot when providing all fields: output 1`] = `
 ContributorEntity {
   "avatarUrl": "https://avatars.githubusercontent.com/u/20110076?v=4",
-  "id": "20110076",
+  "id": "github/20110076",
   "repositories": Array [],
   "username": "ZibanPirate",
 }
@@ -16,7 +16,7 @@ exports[`should match snapshot when providing required fields only: errors 1`] =
 exports[`should match snapshot when providing required fields only: output 1`] = `
 ContributorEntity {
   "avatarUrl": "https://avatars.githubusercontent.com/u/20110076?v=4",
-  "id": "20110076",
+  "id": "github/20110076",
   "username": "ZibanPirate",
 }
 `;

--- a/packages/models/src/contributor/index.spec.ts
+++ b/packages/models/src/contributor/index.spec.ts
@@ -6,7 +6,7 @@ runDTOTestCases(
   ContributorEntity,
   {
     avatarUrl: "https://avatars.githubusercontent.com/u/20110076?v=4",
-    id: "20110076",
+    id: "github/20110076",
     username: "ZibanPirate",
   },
   {

--- a/packages/models/src/project-reference/index.ts
+++ b/packages/models/src/project-reference/index.ts
@@ -4,6 +4,7 @@ import { ValidateNested } from "class-validator";
 import { BaseEntity, Model } from "src/_base";
 import { RepositoryReferenceEntity } from "src/repository-reference";
 
+// @TODO-ZM: remove this
 export class ProjectReferenceEntity extends BaseEntity {
   @IsString()
   slug!: string;

--- a/packages/models/src/project/index.ts
+++ b/packages/models/src/project/index.ts
@@ -1,10 +1,15 @@
 import { Type } from "class-transformer";
-import { ValidateNested } from "class-validator";
-import { Model } from "src/_base";
-import { ProjectReferenceEntity } from "src/project-reference";
+import { IsString, ValidateNested } from "class-validator";
+import { BaseEntity, Model } from "src/_base";
 import { RepositoryEntity } from "src/repository";
 
-export class ProjectEntity extends ProjectReferenceEntity {
+export class ProjectEntity extends BaseEntity {
+  @IsString()
+  slug!: string;
+
+  @IsString()
+  name!: string;
+
   @ValidateNested({ each: true })
   @Type(() => RepositoryEntity)
   declare repositories: Model<RepositoryEntity>[];

--- a/packages/models/src/repository-reference/index.ts
+++ b/packages/models/src/repository-reference/index.ts
@@ -1,6 +1,7 @@
 import { IsString } from "class-validator";
 import { BaseEntity } from "src/_base";
 
+// @TODO-ZM: to remove this
 export class RepositoryReferenceEntity extends BaseEntity {
   @IsString()
   provider!: "github" | "gitlab";

--- a/packages/models/src/repository/__snapshots__/index.spec.ts.snap
+++ b/packages/models/src/repository/__snapshots__/index.spec.ts.snap
@@ -9,6 +9,13 @@ RepositoryEntity {
   "owner": "dzcode-io",
   "provider": "github",
   "repository": "leblad",
+  "stats": RepositoryStatsEntity {
+    "contributionCount": 10,
+    "languages": Array [
+      "TypeScript",
+      "Rust",
+    ],
+  },
 }
 `;
 
@@ -27,7 +34,7 @@ Array [
   ValidationError {
     "children": Array [],
     "constraints": Object {
-      "isString": "provider must be a string",
+      "isIn": "provider must be one of the following values: github, gitlab",
     },
     "property": "provider",
     "target": RepositoryEntity {},

--- a/packages/models/src/repository/index.spec.ts
+++ b/packages/models/src/repository/index.spec.ts
@@ -12,5 +12,6 @@ runDTOTestCases(
   {
     contributions: [],
     contributors: [],
+    stats: { contributionCount: 10, languages: ["TypeScript", "Rust"] },
   },
 );

--- a/packages/models/src/repository/index.ts
+++ b/packages/models/src/repository/index.ts
@@ -1,11 +1,33 @@
 import { Type } from "class-transformer";
-import { ValidateNested } from "class-validator";
-import { Model } from "src/_base";
+import { IsIn, IsNumber, IsString, ValidateNested } from "class-validator";
+import { BaseEntity, Model } from "src/_base";
 import { ContributionEntity } from "src/contribution";
 import { ContributorEntity } from "src/contributor";
-import { RepositoryReferenceEntity } from "src/repository-reference";
 
-export class RepositoryEntity extends RepositoryReferenceEntity {
+export class RepositoryStatsEntity extends BaseEntity {
+  @IsNumber()
+  contributionCount!: number;
+
+  @IsString({ each: true })
+  languages!: string[];
+}
+
+const RepositoryProviders = ["github", "gitlab"] as const;
+type RepositoryProvider = typeof RepositoryProviders[number];
+
+export class RepositoryEntity extends BaseEntity {
+  @IsIn(RepositoryProviders)
+  provider!: RepositoryProvider;
+
+  @IsString()
+  owner!: string;
+
+  @IsString()
+  repository!: string;
+
+  @Type(() => RepositoryStatsEntity)
+  stats?: Model<RepositoryStatsEntity>;
+
   @ValidateNested({ each: true })
   @Type(() => ContributorEntity)
   contributors?: Model<ContributorEntity>[];


### PR DESCRIPTION
# Description

added a new endpoint in `./api`, that returns the projects listed under dzcode and display more info for each project such as contributors ...etc

you can test it by:
```sh
curl -X 'GET' \
  'http://localhost:7070/Projects/' \
  -H 'accept: text/html; charset=utf-8'
```

or by visiting:
http://localhost:7070/docs/#/Project/ProjectController.getProjects

## Type of change

<!-- Please delete options that are not relevant. -->

- New feature (non-breaking change which adds functionality)
