### PR TITLE
Fixed bug where projects endpoint stuck

### DIFF
--- a/api/src/fetch/service.ts
+++ b/api/src/fetch/service.ts
@@ -1,4 +1,4 @@
-import { lock } from "@dzcode.io/utils/dist/concurrency";
+import { lockFactory } from "@dzcode.io/utils/dist/concurrency";
 import { defaults } from "make-fetch-happen";
 import { ConfigService } from "src/config/service";
 import { Service } from "typedi";
@@ -28,9 +28,11 @@ export class FetchService {
   };
 
   private makeFetchHappenInstance;
-  private fetch = lock(async <T>(url: string, { headers }: Omit<FetchConfig, "params"> = {}) => {
-    const response = await this.makeFetchHappenInstance(url, { headers });
-    const jsonResponse = (await response.json()) as T;
-    return jsonResponse;
-  });
+  private fetch = lockFactory(
+    async <T>(url: string, { headers }: Omit<FetchConfig, "params"> = {}) => {
+      const response = await this.makeFetchHappenInstance(url, { headers });
+      const jsonResponse = (await response.json()) as T;
+      return jsonResponse;
+    },
+  );
 }

--- a/api/src/project/controller.ts
+++ b/api/src/project/controller.ts
@@ -1,3 +1,4 @@
+import { AccountEntity } from "@dzcode.io/models/dist/account";
 import { Controller, Get } from "routing-controllers";
 import { OpenAPI, ResponseSchema } from "routing-controllers-openapi";
 import { DataService } from "src/data/service";
@@ -34,35 +35,34 @@ export class ProjectController {
           repositories: await Promise.all(
             repositories.map(async ({ provider, owner, repository }) => {
               let contributionCount = 0;
+              let contributors: AccountEntity[] = [];
+              let languages: string[] = [];
               try {
-                contributionCount = (
-                  await this.githubService.listRepositoryIssues({ owner, repository })
-                ).length;
+                [contributionCount, contributors, languages] = await Promise.all([
+                  (await this.githubService.listRepositoryIssues({ owner, repository })).length,
+                  await Promise.all(
+                    (
+                      await this.githubService.listRepositoryContributors({ owner, repository })
+                    ).map(async ({ login }) => {
+                      const githubUser = await this.githubService.getUser({ username: login });
+                      return this.githubService.githubUserToAccountEntity(githubUser);
+                    }),
+                  ),
+                  await this.githubService.listRepositoryLanguages({ owner, repository }),
+                ]);
               } catch (error) {
-                this.loggerService.warn({
-                  message: `Failed to fetch contributionCount for ${owner}/${repository}: ${error}`,
-                  meta: { owner, repository },
+                this.loggerService.error({
+                  message: `Failed to fetch rich info for project: ${owner}/${repository}`,
+                  meta: { owner, repository, error },
                 });
               }
+
               return {
                 provider,
                 owner,
                 repository,
-                stats: {
-                  contributionCount,
-                  languages: await this.githubService.listRepositoryLanguages({
-                    owner,
-                    repository,
-                  }),
-                },
-                contributors: await Promise.all(
-                  (
-                    await this.githubService.listRepositoryContributors({ owner, repository })
-                  ).map(async ({ login }) => {
-                    const githubUser = await this.githubService.getUser({ username: login });
-                    return this.githubService.githubUserToAccountEntity(githubUser);
-                  }),
-                ),
+                stats: { contributionCount, languages },
+                contributors,
               };
             }),
           ),

--- a/packages/utils/src/concurrency/index.ts
+++ b/packages/utils/src/concurrency/index.ts
@@ -6,7 +6,7 @@ interface QueueObject {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const lock = <T extends (...args: any) => Promise<any>>(func: T): T => {
+export const lockFactory = <T extends (...args: any) => Promise<any>>(func: T): T => {
   const queue: Record<string, QueueObject> = {};
   let timer: NodeJS.Timer | null = null;
 
@@ -63,7 +63,6 @@ export const lock = <T extends (...args: any) => Promise<any>>(func: T): T => {
         callbacks[index](undefined, error);
       }
     }
-    delete queue[queueKeys[0]];
   };
 
   return lockedFunction as T;


### PR DESCRIPTION
and made `/project` endpoint fail gracefully when rich info fetching fails.

the bug was caused by a duplicate delete statement [here](https://github.com/dzcode-io/dzcode.io/pull/581/files?diff=unified&w=1#diff-c87f7bb1e49f256f08c6865cbbbb55660edd0f8667f0c91023f5c9d896287b71L66), that keeps eating the queue 2x faster, therefor when we have two parallel fetches, the last added fetch request never get fulfilled because it was deleted from the queue before it was processed. fixed in a9ee14372ce6aa34a87b6faae4fa20f6940dc6dd

#### Type of change

<!-- After your PR is created, please tick the relevant options below -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (changes that require a fresh clone of the repo)
- [ ] I'm not sure
