### PR TITLE
Fix: filtering out contributions created by bots

### DIFF
--- a/api/src/contribution/controller.ts
+++ b/api/src/contribution/controller.ts
@@ -20,6 +20,7 @@ export class ContributionController {
   ): Promise<GetContributionsResponseDto> {
     const { contributions, filters } = await this.contributionRepository.find(
       (contribution) =>
+        !contribution.createdBy.username.includes("[bot]") &&
         (labels.length === 0 || labels.some((label) => contribution.labels.includes(label))) &&
         (languages.length === 0 ||
           languages.some((language) => contribution.languages.includes(language))) &&

--- a/api/src/contribution/repository.ts
+++ b/api/src/contribution/repository.ts
@@ -22,7 +22,7 @@ export class ContributionRepository {
 
     let contributions = (
       await Promise.all(
-        projects.reduce<Promise<Model<ContributionEntity, "project">[]>[]>(
+        projects.reduce<Promise<Model<ContributionEntity, "project" | "createdBy">[]>[]>(
           (pV, { repositories, name, slug }) => [
             ...pV,
             ...repositories
@@ -38,8 +38,7 @@ export class ContributionRepository {
                     owner,
                     repository,
                   });
-                  // @TODO-ZM: filter out the ones created by bots
-                  return issuesIncludingPRs.map<Model<ContributionEntity, "project">>(
+                  return issuesIncludingPRs.map<Model<ContributionEntity, "project" | "createdBy">>(
                     ({
                       number,
                       labels: gLabels,
@@ -49,6 +48,7 @@ export class ContributionRepository {
                       created_at, // eslint-disable-line camelcase
                       updated_at, // eslint-disable-line camelcase
                       comments,
+                      user,
                     }) => ({
                       id: `${number}`,
                       labels: gLabels.map(({ name }) => name),
@@ -64,6 +64,7 @@ export class ContributionRepository {
                       updatedAt: updated_at, // eslint-disable-line camelcase
                       commentsCount: comments,
                       /* eslint-enable camelcase */
+                      createdBy: this.githubService.githubUserToAccountEntity(user),
                     }),
                   );
                 } catch (error) {

--- a/api/src/contribution/types.ts
+++ b/api/src/contribution/types.ts
@@ -31,7 +31,7 @@ export class FilterDto {
 export class GetContributionsResponseDto extends GeneralResponseDto {
   @ValidateNested({ each: true })
   @Type(() => ContributionEntity)
-  contributions!: Model<ContributionEntity, "project">[];
+  contributions!: Model<ContributionEntity, "project" | "createdBy">[];
 
   @ValidateNested({ each: true })
   @Type(() => FilterDto)

--- a/packages/models/src/contribution/__snapshots__/index.spec.ts.snap
+++ b/packages/models/src/contribution/__snapshots__/index.spec.ts.snap
@@ -6,6 +6,13 @@ exports[`should match snapshot when providing all fields: output 1`] = `
 ContributionEntity {
   "commentsCount": 0,
   "createdAt": "2020-02-02T20:22:02.000Z",
+  "createdBy": AccountEntity {
+    "avatarUrl": "https://avatars.githubusercontent.com/u/20110076?v=4",
+    "id": "github/20110076",
+    "name": "Zakaria Mansouri",
+    "profileUrl": "/Account/github/20110076",
+    "username": "ZibanPirate",
+  },
   "id": "71",
   "labels": [
     "discussion",
@@ -32,6 +39,13 @@ exports[`should match snapshot when providing required fields only: output 1`] =
 ContributionEntity {
   "commentsCount": 0,
   "createdAt": "2020-02-02T20:22:02.000Z",
+  "createdBy": AccountEntity {
+    "avatarUrl": "https://avatars.githubusercontent.com/u/20110076?v=4",
+    "id": "github/20110076",
+    "name": "Zakaria Mansouri",
+    "profileUrl": "/Account/github/20110076",
+    "username": "ZibanPirate",
+  },
   "id": "71",
   "labels": [
     "discussion",

--- a/packages/models/src/contribution/index.spec.ts
+++ b/packages/models/src/contribution/index.spec.ts
@@ -18,6 +18,13 @@ runDTOTestCases(
     createdAt: "2020-02-02T20:22:02.000Z",
     updatedAt: "2020-02-02T20:22:02.000Z",
     url: "https://github.com/dzcode-io/leblad/issues/71",
+    createdBy: {
+      id: "github/20110076",
+      username: "ZibanPirate",
+      name: "Zakaria Mansouri",
+      profileUrl: "/Account/github/20110076",
+      avatarUrl: "https://avatars.githubusercontent.com/u/20110076?v=4",
+    },
   },
   {},
 );

--- a/packages/models/src/contribution/index.ts
+++ b/packages/models/src/contribution/index.ts
@@ -1,6 +1,7 @@
 import { Type } from "class-transformer";
 import { IsDateString, IsNumber, IsString, IsUrl, ValidateNested } from "class-validator";
 import { BaseEntity, Model } from "src/_base";
+import { AccountEntity } from "src/account";
 import { ProjectReferenceEntity } from "src/project-reference";
 
 export class ContributionEntity extends BaseEntity {
@@ -13,6 +14,10 @@ export class ContributionEntity extends BaseEntity {
   @ValidateNested()
   @Type(() => ProjectReferenceEntity)
   project!: Model<ProjectReferenceEntity>;
+
+  @ValidateNested()
+  @Type(() => AccountEntity)
+  createdBy!: Model<AccountEntity>;
 
   @IsString()
   type!: "issue" | "pullRequest";


### PR DESCRIPTION
[/Contribute](https://www.dzcode.io/Contribute) page is spammed with cards that are created by bots.

- added `createdBy` to `Contribution` model, that reference an `Account` Model
- we use it, to filter out bot users, when calling `contributionRepository.find`

test:
- [dzcode.io/Contribute](https://www.dzcode.io/Contribute) should still show bot contributions
- [stage.dzcode.io/Contribute](https://stage.dzcode.io/Contribute) won't show bot contributions

#### Type of change

<!-- After your PR is created, please tick the relevant options below -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (changes that require a fresh clone of the repo)
- [ ] I'm not sure
