### PR TITLE
feat: Hourly metrics

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -20,9 +20,7 @@ template: |
   To test on `stage` environment go to:
 
   - [stage.dzcode.io](https://stage.dzcode.io)
-  - [Android](https://play.google.com/store/apps/details?id=io.dzcode.mobile)
-  - [iOS](https://testflight.apple.com/join/XDcfIqdJ)
-  - [Expo](https://expo.dev/@zakman.dev/dzcode?release-channel=stage)
+
 autolabeler:
   - label: "breaking-change"
     body:

--- a/.github/workflows/cd.deploy.stg.yml
+++ b/.github/workflows/cd.deploy.stg.yml
@@ -4,9 +4,6 @@ on:
   push:
     tags:
       - "stg-v*"
-    # @TODO-ZM: remove this
-    branches:
-      - "lighthouse-setup"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ci.hourly.yml
+++ b/.github/workflows/ci.hourly.yml
@@ -2,11 +2,7 @@ name: "Hourly Job"
 
 on:
   schedule:
-    - cron: "0 * * * *"
-  # @TODO-ZM: remove this
-  push:
-    branches:
-      - "hourly-metrics"
+    - cron: "0 * * * *" # every hour
 
 jobs:
   build:

--- a/.github/workflows/ci.hourly.yml
+++ b/.github/workflows/ci.hourly.yml
@@ -1,0 +1,38 @@
+name: "Hourly Job"
+
+on:
+  schedule:
+    - cron: "0 * * * *"
+  # @TODO-ZM: remove this
+  push:
+    branches:
+      - "hourly-metrics"
+
+jobs:
+  build:
+    uses: ./.github/workflows/ci.reusable.build.yml
+    with:
+      node-version: "20"
+      os: "ubuntu-latest"
+
+  lighthouse-stg:
+    needs: build
+    uses: ./.github/workflows/ci.reusable.lighthouse.yml
+    with:
+      serverBaseUrl: "https://lh-stage.dzcode.io"
+      testBaseUrl: "https://stage.dzcode.io"
+      stage: "staging"
+    secrets:
+      LH_SERVER_TOKEN_STG: ${{ secrets.LH_SERVER_TOKEN_STG }}
+      LH_SERVER_TOKEN_PRD: ${{ secrets.LH_SERVER_TOKEN_PRD }}
+
+  lighthouse-prd:
+    needs: build
+    uses: ./.github/workflows/ci.reusable.lighthouse.yml
+    with:
+      serverBaseUrl: "https://lh.dzcode.io"
+      testBaseUrl: "https://dzcode.io"
+      stage: "production"
+    secrets:
+      LH_SERVER_TOKEN_STG: ${{ secrets.LH_SERVER_TOKEN_STG }}
+      LH_SERVER_TOKEN_PRD: ${{ secrets.LH_SERVER_TOKEN_PRD }}

--- a/.github/workflows/ci.reusable.lighthouse.yml
+++ b/.github/workflows/ci.reusable.lighthouse.yml
@@ -81,6 +81,12 @@ jobs:
     env:
       LH_SERVER_BASE_URL: ${{ inputs.serverBaseUrl }}
       LH_SERVER_TOKEN: ${{ inputs.stage == 'staging' && secrets.LH_SERVER_TOKEN_STG || secrets.LH_SERVER_TOKEN_PRD }}
+      # LHCI_BUILD_CONTEXT__COMMIT_TIME is set in "Get current time" step
+      LHCI_BUILD_CONTEXT__AVATAR_URL: "https://avatars.githubusercontent.com/u/63493121?s=200&v=4"
+      LHCI_BUILD_CONTEXT__AUTHOR: "dzcode-io"
+      LHCI_BUILD_CONTEXT__CURRENT_BRANCH: "main"
+      LHCI_BUILD_CONTEXT__COMMIT_MESSAGE: "Automated Lighthouse CI"
+      LHCI_BUILD_CONTEXT__CURRENT_HASH: "run-${{ github.run_id }}-${{ github.run_number }}"
     steps:
       - name: "Git"
         uses: actions/checkout@v4
@@ -100,4 +106,6 @@ jobs:
           pattern: lighthouse*
           merge-multiple: true
           path: ./web/.lighthouseci
+      - name: "Get current time"
+        run: echo "LHCI_BUILD_CONTEXT__COMMIT_TIME=$(date '+%Y-%m-%d %H:%M:%S %z')" >> $GITHUB_ENV
       - run: npx lerna run lh:upload --scope "@dzcode.io/web"

--- a/.github/workflows/ci.reusable.lighthouse.yml
+++ b/.github/workflows/ci.reusable.lighthouse.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: lighthouse output (${{ hashFiles('web/.lighthouseci/**') }})
+          name: lighthouse-${{inputs.stage}} output (${{ hashFiles('web/.lighthouseci/**') }})
           path: ./web/.lighthouseci/**
           if-no-files-found: error
           include-hidden-files: true
@@ -103,7 +103,7 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
-          pattern: lighthouse*
+          pattern: lighthouse-${{inputs.stage}}*
           merge-multiple: true
           path: ./web/.lighthouseci
       - name: "Get current time"


### PR DESCRIPTION
Hourly cron job that measures lighthouse score on pages of dzcode.io and stage.dzcode.io, we can then see the progress of the score over time while we work on #302 
- prd: https://lh.dzcode.io/app/projects/dzcode.io/dashboard?runUrl=https://www.dzcode.io/contribute/
- stg: https://lh-stage.dzcode.io/app/projects/dzcode.io/dashboard?runUrl=https://stage.dzcode.io/contribute/

#### Type of change

- [x] New feature (non-breaking change which adds functionality)
