### PR TITLE
fix: fallback to user prefered mode instead of assuming dark mode for first-time theme load

### DIFF
--- a/web/src/components/top-bar.tsx
+++ b/web/src/components/top-bar.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useMemo, useLayoutEffect, useState, useCallback } from "react";
+import { useMemo, useLayoutEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
 import logoWide from "src/assets/svg/logo-wide.svg";
 import logoSquare from "src/assets/svg/logo-square.svg";
@@ -17,6 +17,8 @@ export interface TopBarProps {
   version: string;
   links: Array<{ localeKey: DictionaryKeys<"navbar-section">; href: string }>;
 }
+
+type Theme = "light" | "dark";
 
 export function TopBar({ version, links }: TopBarProps): JSX.Element {
   const { pathname } = useLocation();
@@ -41,25 +43,17 @@ export function TopBar({ version, links }: TopBarProps): JSX.Element {
 
   const { localize } = useLocale();
 
-  const [isDark, setIsDark] = useState(() => {
-    const savedTheme = localStorage.getItem("theme");
-    const isDark = savedTheme === "dark";
-    return savedTheme ? isDark : true; // default should be dark
+  const [theme, setTheme] = useState((): Theme => {
+    const savedTheme = localStorage.getItem("theme") || "";
+    if (["light", "dark"].includes(savedTheme)) return savedTheme as Theme;
+
+    return window.matchMedia?.("(prefers-color-scheme: light)")?.matches ? "light" : "dark";
   });
 
   useLayoutEffect(() => {
-    const theme = localStorage.getItem("theme");
-    if (theme) {
-      document.documentElement.setAttribute("data-theme", theme);
-    }
-  }, []);
-
-  const toggleTheme = useCallback(() => {
-    const newTheme = isDark ? "light" : "dark";
-    setIsDark(!isDark);
-    localStorage.setItem("theme", newTheme);
-    document.documentElement.setAttribute("data-theme", newTheme);
-  }, [isDark, setIsDark]);
+    localStorage.setItem("theme", theme);
+    document.documentElement.setAttribute("data-theme", theme);
+  }, [theme]);
 
   return (
     <div className="bg-neutral">
@@ -133,12 +127,12 @@ export function TopBar({ version, links }: TopBarProps): JSX.Element {
               <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
             </svg>
             <input
-              onClick={toggleTheme}
+              onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
               id="theme-toggle"
               type="checkbox"
               value="dzcodeLight"
               className="theme-controller toggle"
-              checked={!isDark}
+              checked={theme === "light"}
             />
             <svg
               xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
**The bug:**

clear the cookie and load the website on a system that has light theme preferred

**Expected:**
you should get light mode

**Actual:**
you get dark mode

**Fix:**

when loading the theme from cookie, if no theme is found, try detecting user-prefered theme, and then fallback to dark mode


**NOTE**

also changed the code a bit, to allow for non-binary options, like having a thrid `auto-detect` option, or other theme names

<!-- After creating your PR, please check the relevant options below -->

- [x] Bug fix
- [ ] New feature
- [ ] Other
