### PR TITLE
Add error handling for failed fetch requests

### DIFF
--- a/api/src/fetch/service.ts
+++ b/api/src/fetch/service.ts
@@ -48,6 +48,10 @@ export class FetchService {
   private async fetch<T>(url: string, options: FetchOptions) {
     this.logger.info({ message: `Fetching ${url}` });
     const response = await this.makeFetchHappenInstance(url, options);
+    if (!response.ok) {
+      this.logger.error({ message: `Failed to fetch ${url}`, meta: { status: response.status } });
+      throw new Error(`Failed to fetch ${url}: ${response.statusText}`);
+    }
     const jsonResponse = (await response.json()) as T;
     return jsonResponse;
   }


### PR DESCRIPTION
fixes a bug where non 200 requests are considered successful

<!-- After creating your PR, please check the relevant options below -->

- [x] Bug fix
- [ ] New feature
- [ ] Other
