### PR TITLE
Add the PlugBrain Android app

### DIFF
--- a/data/models/projects/plugbrain/info.json
+++ b/data/models/projects/plugbrain/info.json
@@ -1,0 +1,11 @@
+{
+  "name": "PlugBrain",
+  "repositories": [
+    {
+      "provider": "github",
+      "owner": "msbelaid",
+      "name": "plugbrain"
+    }
+  ],
+  "tags": ["by-algerian"]
+}


### PR DESCRIPTION
Add PlugBrain, an opensource Android app for focus and distraction control using mental math challenges.

- [ ] Bug fix
- [ ] New feature
- [x] Other
